### PR TITLE
Use the @RedisHash annotation instead of @KeySpace

### DIFF
--- a/06-querydsl-web/pom.xml
+++ b/06-querydsl-web/pom.xml
@@ -26,7 +26,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
+			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-mongodb</artifactId>
 			<version>${querydsl.version}</version>
 		</dependency>
@@ -93,7 +93,7 @@
 				<version>${apt.version}</version>
 				<dependencies>
 					<dependency>
-						<groupId>com.mysema.querydsl</groupId>
+						<groupId>com.querydsl</groupId>
 						<artifactId>querydsl-apt</artifactId>
 						<version>${querydsl.version}</version>
 					</dependency>

--- a/06-querydsl-web/src/main/java/example/web/UserController.java
+++ b/06-querydsl-web/src/main/java/example/web/UserController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import com.mysema.query.types.Predicate;
+import com.querydsl.core.types.Predicate;
 
 /**
  * Controller to handle web requests for {@link User}s.

--- a/11-rest-hal-browser/pom.xml
+++ b/11-rest-hal-browser/pom.xml
@@ -29,7 +29,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
+			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-mongodb</artifactId>
 			<version>${querydsl.version}</version>
 		</dependency>
@@ -108,7 +108,7 @@
 				<version>${apt.version}</version>
 				<dependencies>
 					<dependency>
-						<groupId>com.mysema.querydsl</groupId>
+						<groupId>com.querydsl</groupId>
 						<artifactId>querydsl-apt</artifactId>
 						<version>${querydsl.version}</version>
 					</dependency>

--- a/11-rest-hal-browser/src/main/java/example/StoreRepository.java
+++ b/11-rest-hal-browser/src/main/java/example/StoreRepository.java
@@ -26,7 +26,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RestResource;
 
-import com.mysema.query.types.path.StringPath;
+import com.querydsl.core.types.dsl.StringPath;
 
 /**
  * Repository interface for out-of-the-box paginating access to {@link Store}s and a query method to find stores by
@@ -39,7 +39,8 @@ public interface StoreRepository extends PagingAndSortingRepository<Store, Strin
 		QuerydslBinderCustomizer<QStore> {
 
 	@RestResource(rel = "by-location")
-	Page<Store> findByAddressLocationNear(@Param("location") Point location, @Param("distance") Distance distance, Pageable pageable);
+	Page<Store> findByAddressLocationNear(@Param("location") Point location, @Param("distance") Distance distance,
+			Pageable pageable);
 
 	/**
 	 * Tweak the Querydsl binding if collection resources are filtered.

--- a/12-redis/pom.xml
+++ b/12-redis/pom.xml
@@ -17,7 +17,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 <!-- 			<exclusions> -->
 <!-- 				<exclusion> -->
 <!-- 					<artifactId>jedis</artifactId> -->

--- a/14-redis-repositories/pom.xml
+++ b/14-redis-repositories/pom.xml
@@ -19,7 +19,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 
 		<dependency>

--- a/14-redis-repositories/src/main/java/example/Person.java
+++ b/14-redis-repositories/src/main/java/example/Person.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Reference;
-import org.springframework.data.keyvalue.annotation.KeySpace;
+import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.Data;
 
 @Data
-@KeySpace("persons")
+@RedisHash("persons")
 class Person {
 
 	@Id String id;

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.2.RELEASE</version>
+		<version>1.4.0.M1</version>
 	</parent>
 
 	<modules>
@@ -36,7 +36,7 @@
 
 		<apt.version>1.1.3</apt.version>
 		<java.version>1.8</java.version>
-		<querydsl.version>3.6.7</querydsl.version>
+		<querydsl.version>4.0.9</querydsl.version>
 
 	</properties>
 


### PR DESCRIPTION
Redis Repositories use @RedisHash to identify the repository belongs to the Redis module and to create the appropriate repository type. We now use the @RedisHash annotation instead of the previous @KeySpace annotation.
